### PR TITLE
使用<p> </p>代替EPUB正文中的<br/> 

### DIFF
--- a/src/ts/Tools.ts
+++ b/src/ts/Tools.ts
@@ -587,6 +587,22 @@ class Tools {
       .replace(/\n/g, '<br/>')
   }
 
+  // 把所有换行符统一成 <br /> （包括 \n）之后 统一替换添加<p>与</p>， 以对应EPUB文本惯例
+  static replaceEPUBTextWithP(str: string) {
+    return (
+      '<p>' +
+      str
+        .replaceAll(/&/g, '&amp;')
+        .replaceAll(/</g, '&lt;')
+        .replaceAll(/&lt;br/g, '<br')
+        .replaceAll(/<br>/g, '<br/>')
+        .replaceAll(/<br \/>/g, '<br/>')
+        .replaceAll(/\n/g, '<br/>')
+        .replaceAll('<br/>', '</p>\n<p>') +
+      '</p>'
+    )
+  }
+
   // 小说标题里有些符号需要和正文进行不同的处理
   // 标题里的 & 符号必须去掉或将其转换为普通字符
   // 至于换行标记，不知道标题里有没有，如果有的话也需要将其转换成普通符号

--- a/src/ts/download/MakeNovelFile.ts
+++ b/src/ts/download/MakeNovelFile.ts
@@ -33,7 +33,8 @@ class MakeNovelFile {
   static makeEPUB(data: NovelMeta, saveMeta = true): Promise<Blob> {
     return new Promise(async (resolve, reject) => {
       let content = saveMeta ? data.meta + data.content : data.content
-      content = Tools.replaceEPUBText(content)
+      //使用新的function统一替换添加<p>与</p>， 以对应EPUB文本惯例
+      content = Tools.replaceEPUBTextWithP(content)
 
       const userName = Tools.replaceEPUBText(
         Utils.replaceUnsafeStr(data.userName)
@@ -69,8 +70,8 @@ class MakeNovelFile {
         // 有的小说简介里含有 & 符号，需要转换成别的字符，否则会导致阅读器解析时出错
         // 如 https://www.pixiv.net/novel/show.php?id=22260000
         tags: data.tags || [],
-        description:
-          date + '<br/><br/>' + Tools.replaceEPUBText(data.description),
+        //使用新的function统一替换添加<p>与</p>， 以对应EPUB文本惯例
+        description: date + Tools.replaceEPUBTextWithP(data.description),
       })
 
       jepub.uuid(novelURL)

--- a/src/ts/download/MergeNovel.ts
+++ b/src/ts/download/MergeNovel.ts
@@ -182,7 +182,7 @@ class MergeNovel {
    *
    * 这些字符串通常是作品简介、设定资料等，可能包含 html 代码、特殊符号 */
   private handleEPUBDescription(htmlString: string) {
-    return Tools.replaceEPUBText(
+    return Tools.replaceEPUBTextWithP(
       Tools.replaceEPUBDescription(
         Utils.htmlToText(Utils.htmlDecode(htmlString))
       )
@@ -251,7 +251,8 @@ class MergeNovel {
 
       // 循环添加小说内容
       for (const novelData of novelDataArray) {
-        let content = Tools.replaceEPUBText(novelData.content)
+        //使用新的function统一替换添加<p>与</p>， 以对应EPUB文本惯例
+        let content = Tools.replaceEPUBTextWithP(novelData.content)
         const novelID = novelData.id
         // 添加小说里的图片
         const imageList = await downloadNovelEmbeddedImage.getImageList(


### PR DESCRIPTION
原issue: https://github.com/xuejianxianzun/PixivBatchDownloader/issues/433 

今天自己研究了一晚上应该是搞好了，用几个EPUB阅读器测试过都能正常打开

效果如图：
![image](https://github.com/user-attachments/assets/9a08f470-a438-451d-805c-d8f53ce4ba06)

