### PR TITLE
修复关闭小说内嵌图片下载时占位符残留的问题

### DIFF
--- a/src/ts/Tools.ts
+++ b/src/ts/Tools.ts
@@ -780,6 +780,13 @@ class Tools {
     return str
   }
 
+  /** 移除小说正文里的图片占位符 */
+  static removeNovelImageFlags(str: string) {
+    return str
+      .replace(/\[uploadedimage:\d+\]/g, '')
+      .replace(/\[pixivimage:\d+(?:-\d+)?\]/g, '')
+  }
+
   // '[[jumpuri:予約ページ>https://www.amazon.co.jp/dp/4758092486]]'
   // 替换成
   // '予約ページ（https://www.amazon.co.jp/dp/4758092486）'

--- a/src/ts/download/DownloadNovelEmbeddedImage.ts
+++ b/src/ts/download/DownloadNovelEmbeddedImage.ts
@@ -106,6 +106,13 @@ class DownloadNovelEmbeddedImage {
     size: number
     content: string
   }> {
+    if (!settings.downloadNovelEmbeddedImage) {
+      return {
+        size: 0,
+        content: Tools.removeNovelImageFlags(content),
+      }
+    }
+
     const imageList = await this.getImageList(novelId, content, embeddedImages)
 
     let size = 0

--- a/src/ts/download/MakeNovelFile.ts
+++ b/src/ts/download/MakeNovelFile.ts
@@ -65,7 +65,9 @@ class MakeNovelFile {
 
     this.busy = false
 
-    let content = data.content
+    let content = settings.downloadNovelEmbeddedImage
+      ? data.content
+      : Tools.removeNovelImageFlags(data.content)
 
     // 添加元数据
     if (settings.saveNovelMeta) {

--- a/src/ts/download/MergeNovel.ts
+++ b/src/ts/download/MergeNovel.ts
@@ -330,8 +330,11 @@ class MergeNovel {
       }
       // 添加正文
       // 替换换行标签，移除 html 标签
+      const content = settings.downloadNovelEmbeddedImage
+        ? data.content
+        : Tools.removeNovelImageFlags(data.content)
       text.push(
-        data.content.replace(/<br \/>/g, this.CRLF).replace(/<\/?.+?>/g, '')
+        content.replace(/<br \/>/g, this.CRLF).replace(/<\/?.+?>/g, '')
       )
       // 在正文结尾添加换行标记，使得不同章节之间区分开来
       text.push(this.CRLF.repeat(4))


### PR DESCRIPTION
## 修改内容
- 关闭“下载小说里的内嵌图片”时，移除小说正文中的 `[uploadedimage:...]` 和 `[pixivimage:...]` 占位符
- 覆盖单篇 TXT、合并系列 TXT，以及 EPUB 关闭内嵌图片下载时的正文输出

## 验证
- `git diff --check`
- 使用 Node 验证新增占位符清理正则