### PR TITLE
修复问题：新版缩略图里点击收藏按钮不触发下载

### DIFF
--- a/src/ts/WorkThumbnail.ts
+++ b/src/ts/WorkThumbnail.ts
@@ -53,9 +53,19 @@ abstract class WorkThumbnail {
       // 移动端的收藏按钮不是 button，其容器是 div.bookmark
       return el.querySelector('.bookmark')
     } else {
-      // 桌面端的缩略图容器里只有 1 个 button，就是收藏按钮。目前还没有发现有多个 button 的情况
-      if (el.querySelector('button svg[width="32"]')) {
-        return el.querySelector('button') as HTMLButtonElement
+      // 新版缩略图里可能同时存在多个按钮（例如三点菜单和收藏按钮），不能直接返回第一个 button
+      // 优先使用 Pixiv 的收藏按钮标记；某些旧版缩略图没有这个标记，
+      // 此时回退到包含 32px 图标的按钮（返回图标所在的按钮，而不是第一个按钮）
+      const bookmarkBtn = el.querySelector<HTMLButtonElement>(
+        'button[data-ga4-label="bookmark_button"]'
+      )
+      if (bookmarkBtn) {
+        return bookmarkBtn
+      }
+
+      const svgEl = el.querySelector('button svg[width="32"]')
+      if (svgEl) {
+        return svgEl.closest('button') as HTMLButtonElement
       }
 
       // 旧版缩略图里，缩略图元素是 div._one-click-bookmark （例如：各种排行榜页面）


### PR DESCRIPTION
修复 #666

**问题**

开启“点击收藏按钮时下载作品”后，在排行榜页面点击心形收藏按钮不会触发下载；点击三点菜单按钮反而会触发下载。

**原因**

新版缩略图里同时存在三点菜单和心形收藏两个 button，`WorkThumbnail.findBookmarkBtn()` 返回了 DOM 中的第一个 button（三点菜单），导致下载监听绑定错误。

**改动**

- `findBookmarkBtn()` 优先匹配 `button[data-ga4-label="bookmark_button"]`；
- 旧版缩略图回退到包含 32px 图标的按钮（`svg.closest('button')`），而不是第一个 button；
- 更老的 `div._one-click-bookmark` 和移动端逻辑保持不变。

**测试**

已本地打包，Chrome 加载未打包扩展测试通过：排行榜页点击小心心可正常触发下载。