### PR TITLE
fix: 修复 Ugoira 转 WebM 时内存溢出

### DIFF
--- a/src/ts/ConvertUgoira/ConvertUgoira.ts
+++ b/src/ts/ConvertUgoira/ConvertUgoira.ts
@@ -97,6 +97,16 @@ class ConvertUgoira {
 
         const imageBitmapList = await this.getImageBitmapList(file, id)
 
+        // WebM worker 会转移 ImageBitmap 的所有权。不能把已经转移的对象
+        // 留在缓存里，否则同一作品继续转换其他格式时会复用失效对象。
+        if (
+          type === 'webm' &&
+          typeof Worker !== 'undefined' &&
+          typeof OffscreenCanvas !== 'undefined'
+        ) {
+          this.imageBitmapCache.delete(id)
+        }
+
         try {
           // await Utils.sleep(1000)
           // console.count('测试转换错误')
@@ -125,7 +135,7 @@ class ConvertUgoira {
     this.count = this._count - 1
   }
 
-  // 转换成 WebM
+  /** 转换成 WebM */
   public async webm(file: Blob, info: UgoiraInfo, id: number): Promise<Blob> {
     // WebM 视频的帧延迟不能大于 32767 ms，否则就无法转换成功
     // 其他格式没有这个问题
@@ -148,30 +158,38 @@ class ConvertUgoira {
     // 这不是 bug，而是视频编码的常见兼容性问题（H.264/H.265 也有类似要求）。
     // 播放器渲染链路（尤其是某些内置解码器 + Renderer）处理 padding 不够完美时，就会露出绿线。
 
-    const blob = await this.start(file, info, 'webm', id)
-    this.clearCache(id)
-    return blob
+    try {
+      return await this.start(file, info, 'webm', id)
+    } finally {
+      this.clearCache(id)
+    }
   }
 
-  // 转换成 WebP
+  /** 转换成 WebP */
   public async webp(file: Blob, info: UgoiraInfo, id: number): Promise<Blob> {
-    const blob = await this.start(file, info, 'webp', id)
-    this.clearCache(id)
-    return blob
+    try {
+      return await this.start(file, info, 'webp', id)
+    } finally {
+      this.clearCache(id)
+    }
   }
 
-  // 转换成 GIF
+  /** 转换成 GIF */
   public async gif(file: Blob, info: UgoiraInfo, id: number): Promise<Blob> {
-    const blob = await this.start(file, info, 'gif', id)
-    this.clearCache(id)
-    return blob
+    try {
+      return await this.start(file, info, 'gif', id)
+    } finally {
+      this.clearCache(id)
+    }
   }
 
-  // 转换成 APNG
+  /** 转换成 APNG */
   public async apng(file: Blob, info: UgoiraInfo, id: number): Promise<Blob> {
-    const blob = await this.start(file, info, 'png', id)
-    this.clearCache(id)
-    return blob
+    try {
+      return await this.start(file, info, 'png', id)
+    } finally {
+      this.clearCache(id)
+    }
   }
 
   /** 从转换中列表移除 id，并在一定时间后清理不再使用的 ImageBitmap 缓存 */

--- a/src/ts/ConvertUgoira/ToWebMUseWhammy.ts
+++ b/src/ts/ConvertUgoira/ToWebMUseWhammy.ts
@@ -82,7 +82,7 @@ class ToWebM {
     })
   }
 
-  // 使用 worker 进行绘制和 WebM 编码，避免在主线程上执行 canvas.toDataURL 和 Whammy 编码
+  /** 使用 worker 进行绘制和 WebM 编码，避免在主线程上执行 canvas.toDataURL 和 Whammy 编码 */
   private encodeInWorker(
     ImageBitmapList: ImageBitmap[],
     info: UgoiraInfo
@@ -108,14 +108,19 @@ class ToWebM {
       }
 
       this.worker.addEventListener('message', handler)
-      this.worker.postMessage({
-        id,
-        bitmaps: ImageBitmapList,
-        delays: info.frames!.map((frame) => frame.delay),
-        width: ImageBitmapList[0].width,
-        height: ImageBitmapList[0].height,
-        quality: 0.9,
-      })
+      // ImageBitmap 是可转移对象。若不提供 transfer list，浏览器会尝试复制
+      // 所有帧的像素数据；大体积动图会因此触发 DataCloneError: out of memory。
+      this.worker.postMessage(
+        {
+          id,
+          bitmaps: ImageBitmapList,
+          delays: info.frames!.map((frame) => frame.delay),
+          width: ImageBitmapList[0].width,
+          height: ImageBitmapList[0].height,
+          quality: 0.9,
+        },
+        ImageBitmapList
+      )
     })
   }
 }


### PR DESCRIPTION
### 问题
Ugoira 转换为 WebM 时，主线程通过普通 postMessage 将所有 ImageBitmap 发送给 Worker。Chrome 会尝试复制全部帧的像素数据，导致内存占用过高并抛出：
DataCloneError: Failed to execute 'postMessage' on 'Worker':
Data cannot be cloned, out of memory.

### 修复内容
使用 transfer list 传输 ImageBitmap，避免复制像素数据：
this.worker.postMessage(payload, ImageBitmapList)
 - 转换失败时清理任务状态和缓存；
 - 为相关 class 方法补充 JSDoc。

### 测试
已测试pid: 104933944(没找到其他可测试的qaq)

Fix: https://github.com/xuejianxianzun/PixivBatchDownloader/issues/663